### PR TITLE
android: encoder: Add Metadata Buffers mode support

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -159,7 +159,9 @@ LOCAL_CPPFLAGS := \
 
 LOCAL_C_INCLUDES := \
 	frameworks/native/include/media/openmax \
+	frameworks/native/libs/nativebase/include \
 	hardware/xilinx/vcu/vcu-ctrl-sw/include \
+	device/xilinx/common/gralloc \
 	$(LOCAL_PATH)/omx_header_for_android
 
 OMX_COMPONENT_ENC_SRCS := \

--- a/base/omx_component/omx_buffer_handle.cpp
+++ b/base/omx_component/omx_buffer_handle.cpp
@@ -38,10 +38,21 @@
 #include "omx_buffer_handle.h"
 
 OMXBufferHandle::OMXBufferHandle(OMX_BUFFERHEADERTYPE* header) : BufferHandleInterface((char*)header->pBuffer, header->nAllocLen), header(header)
+#ifdef ANDROID
+  ,handle(NULL)
+#endif
 {
   offset = header->nOffset;
   payload = header->nFilledLen;
 }
+
+#ifdef ANDROID
+OMXBufferHandle::OMXBufferHandle(private_handle_t* handle, OMX_BUFFERHEADERTYPE* header) : BufferHandleInterface((char*)(uintptr_t)(handle->share_fd), handle->size), header(header), handle(handle)
+{
+  offset = handle->offset;
+  payload = handle->size;
+}
+#endif
 
 OMXBufferHandle::~OMXBufferHandle() = default;
 

--- a/base/omx_component/omx_buffer_handle.h
+++ b/base/omx_component/omx_buffer_handle.h
@@ -41,11 +41,21 @@
 
 #include <OMX_Core.h>
 
+#ifdef ANDROID
+#include <gralloc_priv.h>
+#endif
+
 struct OMXBufferHandle : BufferHandleInterface
 {
   OMXBufferHandle(OMX_BUFFERHEADERTYPE* header);
+#ifdef ANDROID
+  OMXBufferHandle(private_handle_t* handle, OMX_BUFFERHEADERTYPE* header);
+#endif
   ~OMXBufferHandle() override;
 
   OMX_BUFFERHEADERTYPE* const header;
+#ifdef ANDROID
+  private_handle_t* const handle;
+#endif
 };
 

--- a/base/omx_component/omx_component.cpp
+++ b/base/omx_component/omx_component.cpp
@@ -233,6 +233,9 @@ Component::Component(OMX_HANDLETYPE component, shared_ptr<MediatypeInterface> me
   shouldClearROI = false;
   shouldPushROI = false;
   shouldFireEventPortSettingsChanges = true;
+#ifdef ANDROID
+  inputMetaDataBufferMode = false;
+#endif
   version.nVersion = ALLEGRODVT_OMX_VERSION;
   AssociateSpecVersion(spec);
 
@@ -1201,6 +1204,9 @@ OMX_ERRORTYPE Component::FillThisBuffer(OMX_IN OMX_BUFFERHEADERTYPE* header)
 
 void Component::ComponentDeInit()
 {
+#ifdef ANDROID
+  inputMetaDataBufferMode = false;
+#endif
   if(eosHandles.input)
   {
     delete eosHandles.input;
@@ -1469,6 +1475,12 @@ OMX_ERRORTYPE Component::GetExtensionIndex(OMX_IN OMX_STRING name, OMX_OUT OMX_I
   if (!strcmp(name, "OMX.google.android.index.useAndroidNativeBuffer"))
   {
     *index = static_cast<OMX_INDEXTYPE>(OMX_ALG_IndexExtUseNativeBuffer);
+    return OMX_ErrorNone;
+  }
+
+  if (!strcmp(name, "OMX.google.android.index.storeANWBufferInMetadata"))
+  {
+    *index = static_cast<OMX_INDEXTYPE>(OMX_ALG_IndexExtStoreMetaDataInBuffers);
     return OMX_ErrorNone;
   }
 

--- a/base/omx_component/omx_component.h
+++ b/base/omx_component/omx_component.h
@@ -137,6 +137,9 @@ protected:
   bool shouldClearROI;
   bool shouldPushROI;
   bool shouldFireEventPortSettingsChanges;
+#ifdef ANDROID
+  bool inputMetaDataBufferMode;
+#endif
   std::vector<OMXSei> tmpSeis;
 
   OMX_STRING name;

--- a/omx_header_for_android/OMX_IndexAlg.h
+++ b/omx_header_for_android/OMX_IndexAlg.h
@@ -124,6 +124,7 @@ typedef enum OMX_ALG_INDEXTYPE
   OMX_ALG_IndexExtEnableNativeBuffer,                 /**< reference: EnableNativeBuffer */
   OMX_ALG_IndexExtGetNativeBufferUsage,               /**< reference: GetNativeBufferUsage */
   OMX_ALG_IndexExtUseNativeBuffer,                    /**< reference: UseNativeBuffer */
+  OMX_ALG_IndexExtStoreMetaDataInBuffers,             /**< reference: StoreMetaDataInBuffers */
 
   OMX_ALG_IndexMaxEnum = 0x7FFFFFFF,
 }OMX_ALG_INDEXTYPE;


### PR DESCRIPTION
Support Android StoreMetaDataInBuffers extension.

See frameworks/native/headers/media_plugin/media/hardware/HardwareAPI.h
for the details.

In this mode encoder receives in input buffers pointer to the
AndroidNativeWindow objects which contain pointer Gralloc handles.

Add changes to translate these input buffers to Allegro format.

Signed-off-by: Alexey Firago <alexey_firago@mentor.com>